### PR TITLE
Make sure fast_yaml isn't compiled to native code

### DIFF
--- a/src/fast_yaml.erl
+++ b/src/fast_yaml.erl
@@ -23,6 +23,8 @@
 
 -module(fast_yaml).
 
+-compile(no_native).
+
 %% API
 -export([load_nif/0, decode/1, decode/2, start/0, stop/0,
          decode_from_file/1, decode_from_file/2, encode/1, format_error/1]).


### PR DESCRIPTION
NIFs [cannot](http://erlang.org/pipermail/erlang-questions/2011-June/059237.html) be loaded from a HiPE-compiled module.
