### PR TITLE
Handle erlang escape sequences

### DIFF
--- a/test/test5.yml
+++ b/test/test5.yml
@@ -1,0 +1,13 @@
+---
+Name: Backslash
+Source: "\\\\\\\\"
+---
+Name: Double_Quote
+Source: "\"\""
+---
+Name: Backslash_and_Double_Quote
+Source: "\"\\\"\""
+---
+Name: New_Line
+Source: "\\n"
+...


### PR DESCRIPTION
This PR aim to fix the encoding of most Erlang escape sequences listed here: 
[Erlang escape sequnces](http://erlang.org/doc/reference_manual/data_types.html#escape-sequences)
Only one escape sequence is not handled, `/d` (delete) because the decoding fail.

Currently, only 2 escape sequences are handled: 
- double quote: `\"`
- backslash: `\\`

For other escape sequences:
- `fast_yaml:encode` generate an io_list that can't be written into a file, ex: vertical tab `\v`
`1> Binary = <<"\v  ok">>.`
`2> Encoded = encode([[{'Source', Binary}]]).`
`[[[],"- ",[["\n","  ",["Source",": ",[34,"\v  ok",34]]]]]]`
`3> file:write_file(<<"./test.yml">>, Encoded).`
`{error,enoent}`
- Or after an encode -> decode, the escape sequence is replaced by space, ex: new line, carriage return, ...

I've added at least one unitest for each escape sequence.