### PR TITLE
Adds `maps` to `option` type

### DIFF
--- a/src/fast_yaml.erl
+++ b/src/fast_yaml.erl
@@ -31,7 +31,9 @@
 -export([decode/1, decode/2, start/0, stop/0,
          decode_from_file/1, decode_from_file/2, encode/1, format_error/1]).
 
--type option() :: {plain_as_atom, boolean()} | plain_as_atom | {sane_scalars, boolean()} | sane_scalars.
+-type option() :: {plain_as_atom, boolean()} | plain_as_atom |
+                  {sane_scalars, boolean()} | sane_scalars |
+                  {maps, boolean()} | maps.
 -type options() :: [option()].
 -type parser_error() :: {parser_error, binary(), integer(), integer()}.
 -type scanner_error() :: {scanner_error, binary(), integer(), integer()}.


### PR DESCRIPTION
Hello and thank you for this library.

I was trying it out on a toy project. When using the `maps` option, my tests pass so everything seems to be working fine. But dialyzer seems unhappy about it.
```elixir
:fast_yaml.decode_from_file(file_path, maps: true)
```

It looked like the `option` type did not include the `maps` option. I am still unfamiliar with Erlang, so I may very well have missed something :see_no_evil: 