### PR TITLE
Support linking against LibYAML on Windows

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,9 @@
 
 {erl_opts, [debug_info, {src_dirs, ["src"]}]}.
 {port_env, [{"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
-            {"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lyaml"}]}.
+            {"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lyaml"},
+            {"win32", "CFLAGS", "$CFLAGS /DYAML_DECLARE_STATIC"},
+            {"win32", "LDFLAGS", "$LDFLAGS yaml.lib"}]}.
 {port_specs, [{"priv/lib/fast_yaml.so", ["c_src/fast_yaml.c"]}]}.
 
 {deps, [{p1_utils, ".*", {git, "https://github.com/processone/p1_utils", {tag, "1.0.25"}}}]}.


### PR DESCRIPTION
Specify the required flags for linking (statically) against [LibYAML on Windows][1] using MSVC (usage of the Microsoft toolchain is [assumed][2] by the [port compiler][3] as well).

The port compiler offers no easy way to support both static and dynamic linking on Windows (but the user can still control whether or not to link MSVCRT statically).

[1]: https://vcpkg.info/port/libyaml
[2]: https://github.com/blt/port_compiler/blob/v1.14.0/src/pc_port_env.erl#L278-L306
[3]: https://github.com/blt/port_compiler