### PR TITLE
build: append *BSD library and include paths

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,8 @@
 
 {erl_opts, [debug_info, {src_dirs, ["src"]}]}.
 {port_env, [{"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
-            {"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lyaml"},
+            {"CFLAGS", "$CFLAGS -I/usr/local/include"},
+            {"LDFLAGS", "$LDFLAGS -lyaml -L/usr/local/lib"},
             {"win32", "CFLAGS", "$CFLAGS /DYAML_DECLARE_STATIC"},
             {"win32", "LDFLAGS", "$LDFLAGS yaml.lib"}]}.
 {port_specs, [{"priv/lib/fast_yaml.so", ["c_src/fast_yaml.c"]}]}.


### PR DESCRIPTION
BSDs require additional include and library dirs for C compilation;
this change should not impact other platforms.